### PR TITLE
Feature/more graphs

### DIFF
--- a/cogs/AutoUpdate.py
+++ b/cogs/AutoUpdate.py
@@ -216,6 +216,7 @@ class AutoUpdater(commands.Cog):
         updating = await up.update(self.bot.http_session)
         self.bot.news = utils.load_news()
         self.bot._data = utils.load_pickle()
+        self.bot._populations = utils.load_populations()
         logger.info("New data downloaded")
         try:
             await plot_csv(utils.STATS_PATH, self.bot._data)

--- a/cogs/Datacmds.py
+++ b/cogs/Datacmds.py
@@ -10,7 +10,7 @@ from pymysql.err import IntegrityError
 
 import src.utils as utils
 from src.database import db
-from src.plotting import PlotEmpty, plot_csv
+from src.plotting import PlotEmpty, plot_csv, plot_graph
 
 
 class Datacmds(commands.Cog):
@@ -275,6 +275,187 @@ class Datacmds(commands.Cog):
 
         embed.set_image(url=f'attachment://{version}')
         await ctx.send(file=img, embed=embed)
+
+    @commands.command(name="graph", aliases=["g"])
+    @commands.cooldown(3, 30, commands.BucketType.user)
+    async def graph(self, ctx, *args):
+        #c!graph <proportion | ...> <confirmed/recovered/deaths/active> <top | country[]>
+
+        # graph is going to be store in files with names:
+        # es_it_gb_us-proportion-deaths.png
+        # most-proportion-confirmed.png
+
+        types = ['proportion']
+
+        description = {
+            'proportion': "This shows the **percentage of the population** who have confirmed/recovered/died/active."
+        }
+
+        img = None
+
+        ## START WITH INPUT VALIDATION
+        if len(args) < 3:
+            embed = discord.Embed(
+                    description=f"Not enough args provided, I can't tell you which country/region/graph type if you won't tell me everything!\n\n__Examples:__\n `{ctx.prefix}g proportion deaths gb us it de fr`\n`{ctx.prefix}g proportion confirmed top`",
+                    color=utils.COLOR,
+                    timestamp=utils.discord_timestamp()
+                )
+            embed.set_author(name=f"Coronavirus COVID-19 Graphs",
+                        url="https://www.who.int/home",
+                        icon_url=self.bot.author_thumb)
+        else:
+            # at least 2 arguments have been provided
+            if args[0] not in types:
+                # 1st argument is not an available graph type
+                embed = discord.Embed(
+                    description="Your first argument should tell me which kind of graph you would like to see. (proportion/[WIP])",
+                    color=utils.COLOR,
+                    timestamp=utils.discord_timestamp()
+                )
+            elif args[1] not in ['confirmed', 'recovered', 'deaths', 'active']:
+                # 2nd argument is not an available measure
+                embed = discord.Embed(
+                    description="Your second argument should tell me which kind of measure you would like to graph. (confirmed/recovered/deaths/active)",
+                    color=utils.COLOR,
+                    timestamp=utils.discord_timestamp()
+                )
+            else:
+                # 1st and 2nd arguments are all good
+                if args[2] == "top":
+                    # user has requested a graph with the most or lease countries for that type
+                    stats = self.bot._data["sorted"]
+                    pop = self.bot._populations
+
+                    calculatedData = {}
+                    
+                    # loop through all stats
+                    for i in range(len(stats)):
+                        if args[0] == "proportion":
+                            if pop[stats[i]["country"]["name"]] == 0:
+                                continue
+                            # calculate current proportion and add to dictionary
+                            calculatedData[stats[i]["country"]["code"]] = int(stats[i]['statistics'][args[1]]) / pop[stats[i]["country"]["name"]] * 100
+
+                    # sort dictionary smallest to largest value
+                    calculatedData = {k: v for k, v in sorted(calculatedData.items(), key=lambda item: item[1], reverse=True)}
+
+                    # get history stats for first x countries in the dict
+                    graph = []
+                    
+                    count = 6
+                    for c in calculatedData:
+                        if count > 0:
+                            check = utils._get_country(self.bot._data, c.lower())
+                            if check:
+                                graph.append(check)
+                        else:
+                            break
+                        count -= 1
+                    for i in range(len(graph)):
+                        if (args[0] == "proportion"):
+                            for j in graph[i]['history']:
+                                graph[i]['history'][j][args[0]] = int(graph[i]['history'][j][args[1]]) / pop[graph[i]["country"]["name"]] * 100
+                            graph[i]['statistics'][args[0]] = int(graph[i]['statistics'][args[1]]) / pop[graph[i]["country"]["name"]] * 100
+                        else:
+                            await ctx.send("Not yet implemented: cogs/Datacmds.py:383")
+
+                    path = args[2] + "-" + args[0] + "-" + args[1] + "-" + utils.STATS_PATH
+
+                    embed = discord.Embed(
+                        description=f"Here is a graph of the **{args[0].capitalize()}** of **{args[1].capitalize()}** of COVID-19. " + description[args[0]],
+                        timestamp=dt.datetime.utcnow(),
+                        color=utils.COLOR
+                    )  
+
+                    for c in graph:
+                        embed.add_field(
+                            name=c['country']['name'],
+                            value=str(round(c['statistics'][args[0]], 5)) + "%"
+                        )
+
+                    if not os.path.exists(path):
+                        await plot_graph(path, graph, args[0], args[1])
+
+                    with open(path, "rb") as p:
+                        img = discord.File(p, filename=path)
+
+                    embed.set_image(url=f'attachment://{path}')    
+
+                else:
+                    # presumably the user has entered one or more countries
+                    pop = self.bot._populations
+                    # check all countries are valid
+                    stats = []
+                    for c in args[2:]:
+                        check = utils._get_country(self.bot._data, c.lower())
+                        if check:
+                            stats.append(check)
+
+                    for i in range(len(stats)):
+                        # calculate proportion and store
+                        ##print(stats[i]['history'])
+                        if (args[0] == "proportion"):
+                            for j in stats[i]['history']:
+                                stats[i]['history'][j][args[0]] = int(stats[i]['history'][j][args[1]]) / pop[stats[i]["country"]["name"]] * 100
+                            stats[i]['statistics'][args[0]] = int(stats[i]['statistics'][args[1]]) / pop[stats[i]["country"]["name"]] * 100
+                        else:
+                            await ctx.send("Not yet implemented: cogs/Datacmds.py:410")
+
+                    # sort the stats in order of highest proportion
+                    n = len(stats)
+                    swapped = True
+                    while swapped:
+                        swapped = False
+                        for i in range(0, n-1):
+                            if stats[i]['statistics'][args[0]] > stats[i+1]['statistics'][args[0]]:
+                                swapped = True
+                                temp = stats[i]
+                                stats[i] = stats[i+1]
+                                stats[i+1] = temp
+                    n = n-1
+
+                    stats.reverse()
+
+                    embed = discord.Embed(
+                        description=f"Here is a graph of the **{args[0].capitalize()}** of **{args[1].capitalize()}** of COVID-19. " + description[args[0]],
+                        timestamp=dt.datetime.utcnow(),
+                        color=utils.COLOR
+                    )  
+
+                    # add field with the data
+                    # also create file path for graph
+                    path = ""
+                    for c in stats:
+                        embed.add_field(
+                            name=c['country']['name'],
+                            value=str(round(c['statistics'][args[0]], 5)) + "%"
+                        )
+
+                        path += f"{c['country']['code'].lower()}_"
+                    path += f"{args[0]}-{args[1]}-{utils.STATS_PATH}"
+
+                    if not os.path.exists(path):
+                        await plot_graph(path, stats, args[0], args[1])
+
+                    with open(path, "rb") as p:
+                        img = discord.File(p, filename=path)
+
+                    embed.set_image(url=f'attachment://{path}')     
+        
+    
+
+            embed.set_author(name=f"Coronavirus COVID-19 Graphs - {args[0].capitalize()} of {args[1].capitalize()}",
+                        url="https://www.who.int/home",
+                        icon_url=self.bot.author_thumb)
+        embed.set_thumbnail(url=self.bot.thumb + str(time.time()))
+        embed.set_footer(
+            text=utils.last_update(utils.DATA_PATH),
+            icon_url=ctx.me.avatar_url
+        )
+        if img != None:
+            await ctx.send(file=img, embed=embed)
+        else:
+            await ctx.send(embed=embed)
 
     @staticmethod
     def _get_idx(args, val):

--- a/cogs/Help.py
+++ b/cogs/Help.py
@@ -46,6 +46,11 @@ class Help(commands.Cog):
             inline=False
         )
         embed.add_field(
+            name=f"📈 **`{ctx.prefix}<g | graph> <proportion> <deaths | confirmed | recovered | active> <top | country[]>`**",
+            value=f"Views graphical statistics. You can find countries with **full name** or **[ISO-3166-1](https://fr.wikipedia.org/wiki/ISO_3166-1)**.\n\n **Proportion**: This is the value / population * 100 \n\n __Examples__ : `{ctx.prefix}graph proportion top`, `{ctx.prefix}g proportion deaths us gb it es mx fr`, `{ctx.prefix}g proportion active gb`",
+            inline=False
+        )
+        embed.add_field(
             name=f"📈 **`{ctx.prefix}country <country>`**",
             value=f"Views information about multiple chosen country/region. You can either use **autocompletion** or **[ISO-3166-1](https://fr.wikipedia.org/wiki/ISO_3166-1)**.\n __Examples__ : `{ctx.prefix}country fr usa it gb`",
             inline=False

--- a/data/populations.csv
+++ b/data/populations.csv
@@ -1,0 +1,253 @@
+﻿China,1438207241
+India,1377233523
+United States,330610570
+Indonesia,272931713
+Pakistan,219992900
+Brazil,212253150
+Nigeria,205052107
+Bangladesh,164354176
+Russia,145922010
+Mexico,128655589
+Japan,126552765
+Ethiopia,114357494
+Philippines,109280343
+Egypt,101930276
+Vietnam,97160127
+Democratic Republic of the Congo,88972681
+Turkey,84153250
+Iran,83771587
+Germany,83730223
+Thailand,69764925
+United Kingdom,67814098
+France,65244628
+Italy,60479424
+Tanzania,59368313
+South Africa,59154802
+Myanmar,54335948
+Kenya,53521116
+South Korea,51260395
+Colombia,50771878
+Spain,46751175
+Uganda,45427637
+Argentina,45111229
+Algeria,43685618
+Sudan,43632213
+Ukraine,43785122
+Iraq,40031626
+Afghanistan,38742911
+Poland,37854825
+Canada,37674770
+Morocco,36820713
+Saudi Arabia,34701377
+Uzbekistan,33368859
+Peru,32876986
+Angola,32644783
+Malaysia,32280610
+Mozambique,31067362
+Ghana,30936375
+Yemen,29687214
+Nepal,29027347
+Venezuela,28451828
+Madagascar,27539106
+Cameroon,26405174
+Ivory Coast,26239250
+North Korea,25756088
+Australia,25439164
+Niger,24014064
+Taiwan,23808164
+Sri Lanka,21395196
+Burkina Faso,20780371
+Mali,20125282
+Romania,19262731
+Malawi,19024426
+Chile,19082804
+Kazakhstan,18730568
+Zambia,18273379
+Guatemala,17846248
+Ecuador,17587526
+Syria,17410293
+Netherlands,17127290
+Senegal,16649599
+Cambodia,16671185
+Chad,16324440
+Somalia,15798020
+Zimbabwe,14818157
+Guinea,13056478
+Rwanda,12883878
+Benin,12055347
+Burundi,11814346
+Tunisia,11793319
+Bolivia,11640159
+Belgium,11579477
+Haiti,11373955
+Cuba,11327988
+South Sudan,11166783
+Dominican Republic,10825682
+Czech Republic,10705012
+Greece,10433037
+Jordan,10182442
+Portugal,10202571
+Azerbaijan,10120555
+Sweden,10086531
+Honduras,9871892
+United Arab Emirates,9865845
+Hungary,9665192
+Tajikistan,9492342
+Belarus,9449940
+Austria,8996022
+Papua New Guinea,8911530
+Israel,8627444
+Switzerland,8641786
+Togo,8237580
+Sierra Leone,7942879
+Hong Kong,7484618
+Laos,7253719
+Paraguay,7114524
+Serbia,6982000
+Bulgaria,6958627
+Libya,6852010
+Lebanon,6831445
+Nicaragua,6608366
+Kyrgyzstan,6501804
+El Salvador,6479609
+Turkmenistan,6012850
+Singapore,5840996
+Denmark,5788108
+Finland,5539002
+Republic of the Congo,5489191
+Slovakia,5459116
+Norway,5412632
+Oman,5078933
+Palestinian Territory,5076280
+Costa Rica,5084636
+Liberia,5032469
+Ireland,4926480
+Central African Republic,4812256
+New Zealand,4814272
+Mauritania,4623535
+Panama,4300667
+Kuwait,4257495
+Croatia,4110214
+Moldova,4035814
+Georgia,3990681
+Eritrea,3536285
+Uruguay,3471314
+Bosnia and Herzegovina,3284806
+Mongolia,3267320
+Armenia,2962137
+Jamaica,2958567
+Qatar,2870922
+Albania,2878420
+Puerto Rico,2874636
+Lithuania,2729553
+Namibia,2531290
+Gambia,2402083
+Botswana,2341649
+Gabon,2214593
+Lesotho,2138799
+Macedonia,2083391
+Slovenia,2078881
+Guinea-Bissau,1958132
+Latvia,1890218
+Kosovo,1845000
+Bahrain,1688629
+Equatorial Guinea,1392950
+Trinidad and Tobago,1398579
+Estonia,1326357
+East Timor,1313184
+Mauritius,1271347
+Cyprus,1205577
+Swaziland,1157707
+Djibouti,985027
+Fiji,895128
+Reunion,894017
+Comoros,865696
+Guyana,785788
+Bhutan,769867
+Solomon Islands,683301
+Macao,647508
+Montenegro,628050
+Luxembourg,623861
+Western Sahara,594215
+Suriname,585561
+Cape Verde,554750
+Maldives,538558
+Malta,441308
+Brunei,436624
+Guadeloupe,400110
+Belize,396120
+Bahamas,392477
+Martinique,375323
+Iceland,340795
+Vanuatu,305623
+French Guiana,297029
+Barbados,287305
+New Caledonia,284938
+French Polynesia,280580
+Mayotte,271417
+Sao Tome and Principe,218308
+Samoa,198147
+Saint Lucia,183458
+Channel Islands,173536
+Guam,168474
+Curacao,163958
+Kiribati,119069
+Micronesia,114776
+Grenada,112418
+Saint Vincent and the Grenadines,110869
+Aruba,106675
+Tonga,105449
+U.S. Virgin Islands,104456
+Seychelles,98224
+Jersey,97857
+Antigua and Barbuda,97764
+Isle of Man,84942
+Andorra,77240
+Dominica,71950
+Guernsey,67052
+Cayman Islands,65564
+Bermuda,62323
+Marshall Islands,59109
+Northern Mariana Islands,57490
+Greenland,56750
+American Samoa,55215
+Saint Kitts and Nevis,53123
+Faroe Islands,48826
+Sint Maarten,42776
+Monaco,39186
+Turks and Caicos Islands,38609
+Saint Martin,38529
+Liechtenstein,38106
+San Marino,33917
+Gibraltar,33693
+British Virgin Islands,30190
+Aland Islands,28007
+Bonaire, Saint Eustatius and Saba ,26173
+Palau,18077
+Cook Islands,17561
+Anguilla,14976
+Tuvalu,11762
+Wallis and Futuna,11276
+Nauru,10810
+Saint Barthelemy,9871
+Saint Helena,6073
+Saint Pierre and Miquelon,5800
+Montserrat,4991
+Antarctica,4400
+British Indian Ocean Territory,4000
+Falkland Islands,3458
+Svalbard and Jan Mayen,2667
+Norfolk Island,2169
+Niue,1624
+Christmas Island,1402
+Tokelau,1354
+Vatican,825
+Holy See,801
+Cocos Islands,596
+French Southern Territories,310
+United States Minor Outlying Islands,300
+Pitcairn,67
+South Georgia and the South Sandwich Islands,30
+Heard Island and McDonald Islands,0
+Bouvet Island,0
+Cruise Ship,0

--- a/main.py
+++ b/main.py
@@ -55,6 +55,7 @@ class Covid(commands.AutoShardedBot):
         self.remove_command("help")
         self._load_extensions()
         self._data = None
+        self._populations = None
         self.news = None
         self.http_session = None
         self.thumb = "https://upload.wikimedia.org/wikipedia/commons/thumb/2/26/COVID-19_Outbreak_World_Map.svg/langfr-1000px-COVID-19_Outbreak_World_Map.svg.png?t="

--- a/src/utils.py
+++ b/src/utils.py
@@ -22,6 +22,7 @@ URI_DATA      = config("uri_data")
 DATA_PATH     = "data/datas.pickle"
 CSV_DATA_PATH = "data/parsed_csv.json"
 NEWS_PATH     = "data/news.pickle"
+POP_PATH      = "data/populations.csv"
 BACKUP_PATH   = "backup/datas.json"
 
 COLOR                    = 0xd6b360
@@ -71,6 +72,14 @@ def load_news():
 def load_pickle():
     with open(DATA_PATH, 'rb') as f:
         return pickle.load(f)
+    
+def load_populations():
+    d = {}
+    with open(POP_PATH, 'r', encoding='utf-8-sig') as f:
+        for line in f:                
+            (key, val) = line.rsplit(',', 1)
+            d[key] = int(val)
+        return d
 
 def string_formatting(data_parsed: dict, param: list=[]) -> Tuple[str, str]:
     max_length = DISCORD_LIMIT - 50


### PR DESCRIPTION
Hi there!

I was thinking it would be interesting to view stats of a list of countries by the proportion of their population affected.

I've put this together, not sure if you want to pull it or not. There's most probably a better way to do some of this, but this could be a good start. 

If you do pull this, I would love to develop it more, maybe by adding the ability to compare total cases/deaths with the list of 
countries you input.

Thanks!
Craig

## How to use:

At the moment, I have only implemented one type of graph, a proportion graph. This is calculated from the number of cases/active/recovered/deaths divided by the population and multiplied by 100 to be a percentage.

`c!graph proportion <deaths/confirmed/active/recovered> <top | country[]>`

You can input either 'top' or a list of countries, eg:
`France Germany es it gb us japan`

![top-proportion-deaths-stats](https://user-images.githubusercontent.com/39021265/86474973-c7248180-bd3b-11ea-8378-7594d0c968bd.png)




![es_gb_it_fr_us_de_jp_proportion-deaths-stats](https://user-images.githubusercontent.com/39021265/86475201-2f736300-bd3c-11ea-9636-94aba0767b13.png)
